### PR TITLE
Fix production CSS: revert Sass @use to @import for GitHub Pages (closes #50)

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -1,4 +1,4 @@
-@use "base";
+@import "base";
 
 .migrationfm {
   .mdl-layout__header-row {

--- a/css/main.scss
+++ b/css/main.scss
@@ -4,4 +4,4 @@
 @charset "utf-8";
 
 // Import partials from `sass_dir` (defaults to `_sass`)
-@use "layout";
+@import "layout";


### PR DESCRIPTION
## 概要

本番サイトで `main.css` が未コンパイルのまま配信される問題を修正。

Closes #50

## 原因

PR #42 で Sass を `@import` から `@use` に変更したが、GitHub Pages のビルド環境が Dart Sass の `@use` 構文に未対応のため、コンパイルが失敗していた。

本番の `main.css` が `@use "layout"` の1行のみを返しており、カスタムスタイルが一切適用されていなかった。

## 変更内容

| ファイル | 変更 |
|---|---|
| `css/main.scss` | `@use "layout"` → `@import "layout"` |
| `_sass/_layout.scss` | `@use "base"` → `@import "base"` |

## テスト

- ローカルで `curl http://localhost:4000/css/main.css` を実行し、完全にコンパイルされた CSS が返ることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)