### PR TITLE
Add GitHub Actions Pages workflow to support Sass @use (closes #50)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '4.0'
           bundler-cache: true
       - uses: actions/configure-pages@v5
         id: pages

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Build and deploy Jekyll site
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      - uses: actions/configure-pages@v5
+        id: pages
+      - run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment


### PR DESCRIPTION
## 概要

GitHub Actions カスタムワークフローを追加し、Dart Sass (`jekyll-sass-converter 3.x` + `sass-embedded`) でビルドすることで Sass `@use` 構文を本番でも動作させる。

Closes #50

## 背景

GitHub Pages の標準ビルドは `jekyll-sass-converter 2.x`（Dart Sass 非対応）を使うため、`@use` がコンパイルされず `main.css` が1行しか返らなかった（Issue #50）。

## 変更内容

`.github/workflows/pages.yml` を追加：
- Ruby 4.0（ローカル環境に合わせた）+ Gemfile.lock の gem をインストール
- `bundle exec jekyll build` で Dart Sass による Sass コンパイルを実行
- `actions/deploy-pages` で GitHub Pages へデプロイ

## マージ後に必要な手動作業 ⚠️

リポジトリの **Settings > Pages > Build and deployment > Source** を  
**「Deploy from a branch」→「GitHub Actions」** に変更してください。

この設定変更をしないとワークフローが起動してもデプロイされません。

## 関連 PR

- PR #51 (`fix/sass-use-github-pages`) は本PRで根本解決されるため不要。クローズ推奨。
- PR #49 (`fix/mdl-cdn-403`) は独立した修正のため引き続き有効。

🤖 Generated with [Claude Code](https://claude.com/claude-code)