### PR TITLE
Update blog URL to note.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,7 @@ facebook_pagename: migration.fm
 rss_url: https://migration.fm/feed.xml
 itunes_url: https://itunes.apple.com/jp/podcast/migration.fm/id1111956465
 andriod_url: https://www.subscribeonandroid.com/migration.fm/feed.xml
-blog_url: https://blog.migration.fm/
+blog_url: https://note.com/a_kuratani/m/m155bfd2bf627
 
 # theme: minima
 theme_color: blue-pink # deep_purple-pink


### PR DESCRIPTION
## Summary
- BlogリンクをNote.comのマガジンURLに変更

## Test plan
- [ ] ヘッダー・フッターのBlogリンクが https://note.com/a_kuratani/m/m155bfd2bf627 に遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)