### PR TITLE
Replace SoundCloud with YouTube/Apple Podcasts player

### DIFF
--- a/_includes/player.html
+++ b/_includes/player.html
@@ -1,0 +1,13 @@
+{% if page.youtube_id %}
+  <div class="youtube">
+    <iframe width="100%" height="auto" style="aspect-ratio: 16/9;" src="https://www.youtube.com/embed/{{ page.youtube_id }}" frameborder="0" allowfullscreen></iframe>
+  </div>
+{% elsif page.apple_podcast_url %}
+  <a href="{{ page.apple_podcast_url }}" class="apple-podcast-tile mdl-shadow--2dp">
+    <div class="apple-podcast-tile__image">
+      <img src="/images/Logo.png" alt="migration.fm">
+      <i class="material-icons">headset</i>
+    </div>
+    <div class="apple-podcast-tile__label">Apple Podcasts で聴く</div>
+  </a>
+{% endif %}

--- a/_includes/soundcloud.html
+++ b/_includes/soundcloud.html
@@ -1,5 +1,0 @@
-{% unless page.soundcloud_url == empty %}
-  <div class="soundcloud">
-    <iframe width="100%" height="166" scrolling="no" frameborder="no" src="{{ page.soundcloud_url }}"></iframe>
-  </div>
-{% endunless %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,7 +21,7 @@ layout: default
 
         <div class="keywords">Keywords: {{ page.keywords }}</div>
 
-        {% include soundcloud.html %}
+        {% include player.html %}
 
         {% include speaker_list.html %}
 

--- a/_posts/2016-04-01-000.md
+++ b/_posts/2016-04-01-000.md
@@ -6,8 +6,7 @@ categories: Podcast
 speaker_list:
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/256530325-migrationfm-ep000.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/256530325&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/0-podcast-%E3%81%AF%E3%81%98%E3%82%81%E3%81%BE%E3%81%97%E3%81%9F/id1111956465?i=1000472780851
 length: "3228004"
 description: "今日はエイプリルフール。ということで、Podcastはじめました。"
 podcastLength: "00:03:21"

--- a/_posts/2016-05-06-001.md
+++ b/_posts/2016-05-06-001.md
@@ -6,8 +6,7 @@ categories: Podcast
 speaker_list:
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/262778564-migrationfm-ep001.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/262778564&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/1-salesforce-trailhead-gw%E3%82%B9%E3%82%AD%E3%83%AB%E3%82%A2%E3%83%83%E3%83%97%E3%82%AD%E3%83%A3%E3%83%B3%E3%83%9A%E3%83%BC%E3%83%B3-summer16%E3%83%AA%E3%83%AA%E3%83%BC%E3%82%B9%E3%83%8E%E3%83%BC%E3%83%88%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6%E3%81%AA%E3%81%A9/id1111956465?i=1000472780872
 length: "11266194"
 description: "Salesforce trailhead の Golden Week スキルアップキャンペーン、Summer'16 のリリースノート、SALESFORCE DEVELOPERS.INFOについて話しました。"
 podcastLength: "00:11:44"

--- a/_posts/2016-05-31-002.md
+++ b/_posts/2016-05-31-002.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/55629814/sunaf_bigger.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/266858387-migrationfm-ep002.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/266858387%3Fsecret_token%3Ds-tt5lL&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/2-summer16-%E3%83%AA%E3%83%AA%E3%83%BC%E3%82%B9%E3%83%8E%E3%83%BC%E3%83%88-salesforce-developers-info-tokyo/id1111956465?i=1000472780869
 length: "22733217"
 description: "ゲストに米井さんをお招きして、Summer'16 リリースノート、SALESFORCE DEVELOPERS.INFO、Tokyo Salesforce Developer Groupの活動などについて話しました。"
 podcastLength: "00:23:40"

--- a/_posts/2016-07-18-003.md
+++ b/_posts/2016-07-18-003.md
@@ -6,8 +6,7 @@ categories: Podcast
 speaker_list:
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/274245201-migrationfm-ep003.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/274245201&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/3-migration-fm-%E3%81%AEweb%E3%82%B5%E3%82%A4%E3%83%88%E6%9B%B4%E6%96%B0-%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%B9-%E3%81%AA%E3%81%A9/id1111956465?i=1000472780858
 length: "15666530"
 description: "migration.fm のWebサイト更新、Salesforce/Heroku の ニュース、SALESFORCE DEVELOPERS.INFO などについてゲストなしで話しました。"
 podcastLength: "00:16:19"

--- a/_posts/2016-08-04-004.md
+++ b/_posts/2016-08-04-004.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/609154801/116544209_f5dd22eee8.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/276813506-migrationfm-ep004.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/276813506&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/4-awesome-salesforce-stomita/id1111956465?i=1000472780867
 length: "26110978"
 description: "ゲストに冨田さんをお招きして、Awesome Salesforce、コミュニティ活動などについて話しました。"
 podcastLength: "00:27:12"

--- a/_posts/2016-09-08-005.md
+++ b/_posts/2016-09-08-005.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/436889326585008129/Q_ihmvTQ.png
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/282286701-migrationfm-5-lets-read-salesforce-developersinfo-zaki_yama.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/282286701&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/5-lets-read-salesforce-developers-info-zaki-yama/id1111956465?i=1000472780859
 length: "35046831"
 description: "ゲストにSalesforce Developers.infoの山崎さんをお招きして、Salesforce Developers.infoをつまみに話しました。"
 podcastLength: "00:36:30"

--- a/_posts/2016-10-19-006.md
+++ b/_posts/2016-10-19-006.md
@@ -10,8 +10,7 @@ speaker_list:
    image_url: /images/Astro.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/289423996-migrationfm-6-eat-sleep-dreamforce-nakayama_san-big-astro.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/289423996&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/6-eat-sleep-dreamforce-nakayama-san-astro/id1111956465?i=1000472780874
 length: "53260929"
 description: "ゲストに中山さん、アストロさんをお招きして、Dreamforce、ついでにサンフランシスコ旅行について話しました。"
 podcastLength: "00:55:29"

--- a/_posts/2016-11-16-007.md
+++ b/_posts/2016-11-16-007.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/956464349899403264/jsDX3axR_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/293799962-migrationfm-7-dreamforce-salesforce-ecosystem-studying-for-engineers-tak4hir0.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/293799962&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/7-dreamforce-salesforce-ecosystem-studying-for-engineers/id1111956465?i=1000472780848
 length: "64385820"
 description: "ゲストに川畑さんをお招きして、Dreamforce、Salesforce EcosystemにおけるSIビジネス、エンジニア論、Lightning Experienceについて話しました。"
 podcastLength: "01:07:04"

--- a/_posts/2016-11-30-008.md
+++ b/_posts/2016-11-30-008.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/521572047911014401/_bezOit_.png
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/296018109-migrationfm-8-engineer-survival-strategy-tzm_freedom.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/296018109&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/8-engineer-survival-strategy-tzm-freedom/id1111956465?i=1000472780852
 length: "76647154"
 description: "ゲストに田実さんをお招きして、台湾旅行、Salesforce MetaMind、エンジニアが働きたい職場、これから学びたい技術、エンジニア生存戦略について話しました。"
 podcastLength: "01:10:34"

--- a/_posts/2016-12-30-009.md
+++ b/_posts/2016-12-30-009.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/55629814/sunaf_bigger.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/300288064-migrationfm-9-ring-out-the-old-year-ring-in-the-new-yonet77.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/300288064&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/9-ring-out-the-old-year-ring-in-the-new-yonet77/id1111956465?i=1000472780875
 
 length: "37052269"
 description: "ゲストに米井さんをお招きして、行く年来る年として2016年をふりかえりました。"

--- a/_posts/2017-02-10-010.md
+++ b/_posts/2017-02-10-010.md
@@ -10,8 +10,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/904205306162380801/vATd90tw_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/307165694-migrationfm-10-whats-your-new-years-resolution-zaki_yama-yodroid1.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/307165694&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/10-whats-your-new-years-resolution-zaki-yama-yokk/id1111956465?i=1000472780868
 
 length: "56697262"
 description: "ゲストに山崎さん、Yokkさんをお招きして、2017年の目標・抱負、Salesforce関連で気になった技術系の記事、エンジニア論などを話しました。"

--- a/_posts/2017-03-27-011.md
+++ b/_posts/2017-03-27-011.md
@@ -6,8 +6,7 @@ categories: Podcast
 speaker_list:
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/314730109-migrationfm-11-wheres-astro.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/314730109&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/11-wheres-astro/id1111956465?i=1000472780864
 length: "15473410"
 description: "ゲストなしで最近のSalesforce界隈の話題について話しました。"
 podcastLength: "00:28:05"

--- a/_posts/2017-04-27-012.md
+++ b/_posts/2017-04-27-012.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1244909471345725441/Vj7XaCD2_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/321256158-migrationfm-12-what-is-the-value-of-mastodon-mitsuhiro.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/321256158&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/12-what-is-the-value-of-mastodon-mitsuhiro/id1111956465?i=1000472780878
 length: "31885549"
 description: "ゲストに岡本さんをお招きしてMastodon、AI(Einsteinなど)について話しました。"
 podcastLength: "01:02:42"

--- a/_posts/2017-04-27-013.md
+++ b/_posts/2017-04-27-013.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1244909471345725441/Vj7XaCD2_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/321360727-migrationfm-13-living-science-fiction-as-an-engineer-mitsuhiro.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/321360727&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/13-living-science-fiction-as-an-engineer-mitsuhiro/id1111956465?i=1000472780881
 length: "27746925"
 description: "ゲストに岡本さんをお招きして未来のインタフェースについて話しました。"
 podcastLength: "00:54:13"

--- a/_posts/2017-05-10-014.md
+++ b/_posts/2017-05-10-014.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1191515093231521792/wzNp7jVc_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/323563764-migrationfm-14-dont-think-about-survival-live-freely-i_sanuki.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/323563764&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/14-dont-think-about-survival-live-freely-i-sanuki/id1111956465?i=1000472780860
 length: "36046367"
 description: "ゲストに讃岐さんをお招きしてTrailheaDX、Salesforce、エンジニア生存戦略などについて話しました。"
 podcastLength: "01:07:35"

--- a/_posts/2017-06-16-015.md
+++ b/_posts/2017-06-16-015.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/782924510622212096/cb2G5SkR.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/328639223-migrationfm-15-salesforce-girls-group-japan-community-is-amazing.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/328639223&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/15-salesforce-girls-group-japan-community-is-amazing/id1111956465?i=1000472780850
 length: "38203486"
 description: "今回は、ゲストに中山さんをお招きして、Salesforce女子部、Trailhead、Summer'17、エンジニア生存戦略について話を伺いました。"
 podcastLength: "01:14:18"

--- a/_posts/2017-07-05-016.md
+++ b/_posts/2017-07-05-016.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1086551020556013568/8iymlzLz_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/332530382-migrationfm-16-customer-success-kimihom.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/332530382&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/16-customer-success-kimihom/id1111956465?i=1000472780849
 length: "30563894"
 description: "今回はゲストに本間さんをお招きして、知り合ったきっかけ、Herokuコミュニティ、カスタマーサクセスなどについて話を伺いました。"
 podcastLength: "01:03:01"

--- a/_posts/2017-07-05-017.md
+++ b/_posts/2017-07-05-017.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1086551020556013568/8iymlzLz_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/332530448-migrationfm-17-where-is-silicon-valley-in-japan-kimihom.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/332530448&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/17-where-is-silicon-valley-in-japan-kimihom/id1111956465?i=1000472780862
 length: "32287887"
 description: "今回は前回に引き続きゲストに本間さんをお招きして、新しい技術、日本のシリコンバレー、よいサービスの作り方などについて話を伺いました。"
 podcastLength: "01:03:40"

--- a/_posts/2017-08-17-018.md
+++ b/_posts/2017-08-17-018.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1014850741180104704/qP-v3_9L_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/338680796-migrationfm-18-can-you-go-back-to-on-premises-niseissa.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/338680796&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/18-can-you-go-back-to-on-premises-niseissa/id1111956465?i=1000472780870
 length: "36697747"
 description: "今回はゲストに小泉さんをお招きして、TrailheaDX、Heroku、クラウドとオンプレミスなどについて話を伺いました。"
 podcastLength: "01:10:01"

--- a/_posts/2017-08-17-019.md
+++ b/_posts/2017-08-17-019.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1014850741180104704/qP-v3_9L_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/338681368-migrationfm-19-deep-heroku-integration-niseissa.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/338681368&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/19-deep-heroku-integration-niseissa/id1111956465?i=1000472780845
 length: "26168673"
 description: "前回に引き続き小泉さんをお招きして、HerokuとSalesforceを使ったインテグレーションなどについて話を伺いました。"
 podcastLength: "00:50:06"

--- a/_posts/2017-10-23-020.md
+++ b/_posts/2017-10-23-020.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1199928852979470336/dtfVVb4f_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/348381668-migrationfm-20-fast-growing-trailhead-shunkosa.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/348381668&amp;color=%23ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/20-fast-growing-trailhead-shunkosa/id1111956465?i=1000472780853
 length: "38823558"
 description: "今回は Trailhead of the year を受賞された小坂さんをお招きして、Salesforce World Tour Tokyo 2017、Winter'18リリースノート、クラウド型コールセンター関連などについて話を伺いました。"
 podcastLength: "01:11:37"

--- a/_posts/2017-11-22-021.md
+++ b/_posts/2017-11-22-021.md
@@ -12,8 +12,7 @@ speaker_list:
    image_url: /images/Astro.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/360733154-migrationfm-21-lets-go-to-dreamforce-next-year-together.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/360733154&amp;color=%23ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/21-lets-go-to-dreamforce-next-year-together-i-sanuki/id1111956465?i=1000472780877
 length: "43735526"
 description: "今回は、Salesforce MVP のお二人、テラスカイの讃岐さん、フレクトの中山さんとDreamforceで中山さんがゲットしたアストロさんたちをお招きして、Dreamfroce 2017 について話を伺いました。"
 podcastLength: "01:23:53"

--- a/_posts/2017-12-20-022.md
+++ b/_posts/2017-12-20-022.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/904862282068312065/EipaTmja_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/373359959-migrationfm-22-exam-emergency-stop-yonet77.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/373359959&amp;color=%23ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/22-exam-emergency-stop-yonet77/id1111956465?i=1000472780854
 length: "15932618"
 description: "今回は、TAOドライブの米井さんをお招きして、認定 Platform デベロッパー、Lightning Platform、TrailheaDX、Dreamforce、Lightning Now Tour Japanなどについて話を伺いました。"
 podcastLength: "00:30:44"

--- a/_posts/2018-01-29-023.md
+++ b/_posts/2018-01-29-023.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/436889326585008129/Q_ihmvTQ.png
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/393895341-migrationfm-23-continuous-study-sessions-zaki_yama.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/393895341&amp;color=%23ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/23-continuous-study-sessions-zaki-yama/id1111956465?i=1000472780873
 length: "45504131"
 description: "今回は、チームスピリットの山﨑さんをお招きして、勉強会、コミュニティ活動、エモい話、Salesforce技術系、TrailheaDXなどについて話しました。"
 podcastLength: "01:25:06"

--- a/_posts/2018-03-13-024.md
+++ b/_posts/2018-03-13-024.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1199928852979470336/dtfVVb4f_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/414652536-migrationfm-24-no-salesforce-no-life-shunkosa.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/414652536%3Fsecret_token%3Ds-yxh2a&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/24-no-salesforce-no-life-shunkosa/id1111956465?i=1000472780865
 length: "32713350"
 description: "今回は、Salesforce MVPに選出された小坂さんをお招きして、Salesforce Spring'18リリースノート、最近のイベント、IdeaSpokes、最近読んだ本などについて話を伺いました。"
 podcastLength: "01:00:14"

--- a/_posts/2018-05-17-025.md
+++ b/_posts/2018-05-17-025.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1213999540358926336/eBAQWuzP_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/445375470-migrationfm-25-when-do-you-start-studying-english-suyaman_jp.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/445375470%3Fsecret_token%3Ds-VUOyC&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/25-when-do-you-start-studying-english-suyaman-jp/id1111956465?i=1000472780857
 length: "30380464"
 description: "今回は、テラスカイの須山さんをお招きして、サンフランシスコ旅行(TrailheaDX)、コミュニティ活動、エンジニア生存戦略、最近のニュースなどについて話を伺いました。"
 podcastLength: "01:00:28"

--- a/_posts/2018-06-25-026.md
+++ b/_posts/2018-06-25-026.md
@@ -12,8 +12,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/770056244971331584/cILrjoMJ_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/463238976-migrationfm-26-lets-dance-with-robohon-and-einstein-nmin000.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/463238976&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/26-lets-dance-with-robohon-and-einstein-nmin000-surounin/id1111956465?i=1000472780880
 length: "36718220"
 description: "今回は、ユー・エス・イーのロボホンズの皆さん（新美さん、岸さん、畑本さん）をお招きして、ロボホンを中心にSalesforce AIアプリコンテストで優勝された話を伺いました。"
 podcastLength: "01:08:09"

--- a/_posts/2018-08-29-027.md
+++ b/_posts/2018-08-29-027.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/521572047911014401/_bezOit_.png
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/495126714-migrationfm-27-doing-apex-on-local-tzm_freedom.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/495126714&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/27-doing-apex-on-local-tzm-freedom/id1111956465?i=1000472780871
 length: "31653342"
 description: "今回は、以前卒業された田実さんをお招きして、Salesforceで技術を学べるのか、Apexのローカル実行環境を作ろう、の話を伺いました。"
 podcastLength: "00:59:03"

--- a/_posts/2018-08-29-028.md
+++ b/_posts/2018-08-29-028.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/521572047911014401/_bezOit_.png
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/495135906-migrationfm-28-evaluating-technical-skills-tzm_freedom.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/495135906&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/28-evaluating-technical-skills-tzm-freedom/id1111956465?i=1000472780855
 length: "42878437"
 description: "今回は、前回に引き続き田実さんをお招きして、ワークフロールールをApexトリガーに変換するツール、Salesforce AIアプリコンテスト、電子書籍、技術力評価会などの話を伺いました。"
 podcastLength: "01:21:13"

--- a/_posts/2018-11-22-029.md
+++ b/_posts/2018-11-22-029.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1401706390700232711/3I82fwFm_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/534738243-migrationfm-29-what-is-your-nickname-ryosuke921186.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/534738243&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/29-what-is-your-nickname-ryosuke921186/id1111956465?i=1000472780861
 length: "22957400"
 description: "今回は、フレクトの小林さんをお招きして、Dreamforce、Salesforce World Tour Tokyo、コミュニティ活動などの話を伺いました。"
 podcastLength: "00:42:29"

--- a/_posts/2018-12-19-030.md
+++ b/_posts/2018-12-19-030.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1199928852979470336/dtfVVb4f_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/548652144-migrationfm-30-communities-around-the-world-shunkosa.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/548652144%3Fsecret_token%3Ds-w534O&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/30-communities-around-the-world-shunkosa/id1111956465?i=1000472780856
 length: "41913203"
 description: "今回は、アクセンチュアの小坂さんをお招きして、認定テクニカルアーキテクト、India Dreamin'、Salesforce World Tour Tokyo、Spring'19リリースノート、Advent Calendarなどの話を伺いました。"
 podcastLength: "01:19:09"

--- a/_posts/2018-12-26-031.md
+++ b/_posts/2018-12-26-031.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/904862282068312065/EipaTmja_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/551453655-migrationfm-31-retrospective-2018-yonet77.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/551453655&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/31-retrospective-2018-yonet77/id1111956465?i=1000472780866
 length: "38618040"
 description: "今回は、TAODriveの米井さんをお招きして、2018年のコミュニティ活動のふりかえりを話しました。"
 podcastLength: "01:14:15"

--- a/_posts/2019-01-26-032.md
+++ b/_posts/2019-01-26-032.md
@@ -6,8 +6,7 @@ categories: Podcast
 speaker_list:
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/569457522-migrationfm-32-japan-dreamin-2019.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/569457522%3Fsecret_token%3Ds-wVvgN&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/32-japan-dreamin-2019/id1111956465?i=1000472780847
 length: "17111881"
 description: "今回は、Japan Dreamin' 2019 に参加して、運営メンバーや参加者の方々にインタビューしました。"
 podcastLength: "00:31:08"

--- a/_posts/2019-02-28-033.md
+++ b/_posts/2019-02-28-033.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/770056244971331584/cILrjoMJ_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/583742067-migrationfm-33-road-to-lightning-champion-surounin.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/583742067%3Fsecret_token%3Ds-uk51u&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/33-road-to-lightning-champion-surounin/id1111956465?i=1000472780879
 length: "28485561"
 description: "今回は、ユー・エス・イーの畑本さんをお招きして、AIアプリコンテスト後の変化、Dreamforce思い出話などを伺いました。"
 podcastLength: "00:57:05"

--- a/_posts/2019-06-19-034.md
+++ b/_posts/2019-06-19-034.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1023577523332866048/FrcdaqEs_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/640512957-migrationfm-34-i-love-codey-nonoukmomo.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/640512957&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/34-i-love-codey-nonoukmomo/id1111956465?i=1000472780846
 length: "27073318"
 description: "今回は、テラスカイの山口さんをお招きして、TrailheaDX、新機能照らす会、コミュニティ参加のきっかけ、好きなAstro&Friendsなどを伺いました。"
 podcastLength: "00:59:45"

--- a/_posts/2019-07-29-035.md
+++ b/_posts/2019-07-29-035.md
@@ -10,8 +10,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1401706390700232711/3I82fwFm_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/660589604-migrationfm-35-interview-with-new-and-old-leaders-yonet77-ryosuke921186.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/660589604&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/35-interview-with-new-and-old-leaders/id1111956465?i=1000472780876
 length: "35812063"
 description: "今回は、TAOドライブの米井さん、フレクトの小林さんをお招きして、Tokyo Salesforce Developer Group、直近のイベント、Peing質問箱に来ている質問の回答などを伺いました。"
 podcastLength: "01:20:33"

--- a/_posts/2019-11-15-036.md
+++ b/_posts/2019-11-15-036.md
@@ -10,8 +10,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/904862282068312065/EipaTmja_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/892500544-migrationfm-36-apologies-for-failure-to-record-cohey1975-yonet77.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/892500544&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/36-apologies-for-failure-to-record-cohey1975-yonet77/id1111956465?i=1000491100888
 length: "2119416"
 description: "今回は、テラスカイ横山さん、TAOドライブ米井さんをゲストにお招きして貴重なお話が失われてしまったお詫びです。"
 podcastLength: "00:04:25"

--- a/_posts/2019-11-22-037.md
+++ b/_posts/2019-11-22-037.md
@@ -10,8 +10,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/770056244971331584/cILrjoMJ_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/720323473-migrationfm-37-dreamforce-japan-night-in-japan-suyaman_jp-surounin.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/720323473%3Fsecret_token%3Ds-NE7zf&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/37-dreamforce-japan-night-in-japan-suyaman-jp-surounin/id1111956465?i=1000472780863
 length: "25412570"
 description: "今回は、テラスカイの須山さん、チームスピリットの畑本さんをお招きして、Dreamforce、Japan Dreamin'、Advent Calendar、Peing質問箱に来ている質問の回答などを伺いました。"
 podcastLength: "00:54:57"

--- a/_posts/2020-05-06-038.md
+++ b/_posts/2020-05-06-038.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1199928852979470336/dtfVVb4f_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/814722220-migrationfm-38-nesting-salesforce-mvps.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/814722220&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/38-nesting-salesforce-mvps-shunkosa/id1111956465?i=1000473778837
 length: "21178399"
 description: "今回は、アクセンチュアの小坂さんをお招きして、リモートワーク、最近のコミュニティ活動、ニュースなどについて話しました。"
 podcastLength: "01:09:19"

--- a/_posts/2020-06-08-039.md
+++ b/_posts/2020-06-08-039.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1189736518555963392/lt9DtLhK_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/839425696-migrationfm-39-lets-talk-about-evangelism-hrk623.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/839425696&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/39-lets-talk-about-evangelism-hrk623/id1111956465?i=1000477904188
 length: "19951677"
 description: "今回は、セールスフォース・ドットコムのデベロッパー・エバンジェリスト田中さんをお招きして、在宅勤務、ウェビナー・キャンペーン、エバンジェリストなどについて話しました。"
 podcastLength: "01:04:16"

--- a/_posts/2020-06-16-040.md
+++ b/_posts/2020-06-16-040.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1401706390700232711/3I82fwFm_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/843535675-migrationfm-40-community-growth-ryosuke921186.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/843535675&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/40-community-growth-ryosuke921186/id1111956465?i=1000478769143
 length: "21104608"
 description: "今回は、フレクトの小林さんをお招きして、Meetupオンライン開催の経験と今後、在宅勤務、B2C Commerceなどについて話しました。"
 podcastLength: "01:04:26"

--- a/_posts/2020-06-25-041.md
+++ b/_posts/2020-06-25-041.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/743076570118524928/VmYAlkqm_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/847714918-migrationfm-41-whats-gyomu-hack-mirygoaround.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/847714918&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/41-whats-gyomu-hack-mirygoaround/id1111956465?i=1000479896497
 length: "31231843"
 description: "今回は、freeeのMiryさんをお招きして、GYOMU Hack、Salesforceを使い倒すなどについて話しました。"
 podcastLength: "01:36:03"

--- a/_posts/2020-09-11-042.md
+++ b/_posts/2020-09-11-042.md
@@ -10,8 +10,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/904862282068312065/EipaTmja_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/892030024-migrationfm-42-salesforce-developers-chatting-cohey1975-yonet77.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/892030024&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/42-salesforce-developers-chatting-cohey1975-yonet77/id1111956465?i=1000491100889
 length: "23466551"
 description: "今回は、テラスカイ横山さん、TAOドライブ米井さんをお招きして、リモートワーク、Salesforce Winter'21 Release、直近のイベントについて雑談しました。"
 podcastLength: "01:11:55"

--- a/_posts/2020-12-26-043.md
+++ b/_posts/2020-12-26-043.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1401706390700232711/3I82fwFm_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/954782851-migrationfm-43-retrospective-by-salesforce-developers.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/954782851&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"
+apple_podcast_url: https://podcasts.apple.com/jp/podcast/43-retrospective-by-salesforce-developers-ryosuke921186/id1111956465?i=1000503652449
 length: "24032118"
 description: "今回は、フレクト小林さんをお招きして、Tokyo Salesforce Developer Groupの活動のふりかえりを通じて、Einstein、リモートワーク、オンラインMeetupやワークショップについて雑談しました。また、来年開催されるJapan Dreamin' 2021、Dreamforce to you Global Gathring Tokyoについて話しました。"
 podcastLength: "01:05:32"

--- a/_posts/2021-03-15-044.md
+++ b/_posts/2021-03-15-044.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1191515093231521792/wzNp7jVc_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/1007570740-migrationfm-44-everything-became-remote-i_sanuki.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1007570740&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"
+youtube_id: "LV8F9JE_FGs"
 length: "21510295"
 description: "今回は、テラスカイの讃岐さんをお招きして、コミュニティ活動、新人教育、CTA、大学講義などについて雑談しました。"
 podcastLength: "01:13:10"

--- a/_posts/2021-04-09-045.md
+++ b/_posts/2021-04-09-045.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1226767743753416704/O8lEq7eE_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/1027028503-migrationfm-45-the-suffering-of-salesforce-admin-takaaki_mo.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1027028503%3Fsecret_token%3Ds-81rtnfUXWUe&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"
+youtube_id: "SX-dBco0uRU"
 length: "13058982"
 description: "今回は、チームスピリットの本橋さんをお招きして、Salesforceのシステム管理者やインテグレーションでよいこと、苦労することなどについて雑談しました。"
 podcastLength: "00:41:51"

--- a/_posts/2021-04-09-046.md
+++ b/_posts/2021-04-09-046.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1226767743753416704/O8lEq7eE_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/1027045348-migrationfm-46-the-road-to-trailblazer-takaaki_mo.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1027045348&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"
+youtube_id: "dzRjK2q5Sbs"
 length: "9791684"
 description: "今回は、チームスピリットの本橋さんをお招きして、Salesforceの勉強方法、コミュニティ、Trailhaed GOなどについて雑談しました。"
 podcastLength: "00:31:06"

--- a/_posts/2021-06-12-047.md
+++ b/_posts/2021-06-12-047.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/904862282068312065/EipaTmja_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/1067632801-migrationfm-47-the-future-of-contract-development-yonet77.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1067632801&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"
+youtube_id: "zXR3dastubg"
 length: "20872082"
 description: "今回は、TAOドライブの米井さんをお招きして、受託開発の未来、SalesforceとHerokuを利用したインテグレーションなどについて話しました。"
 podcastLength: "01:05:06"

--- a/_posts/2021-06-12-048.md
+++ b/_posts/2021-06-12-048.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/904862282068312065/EipaTmja_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/1067633044-migrationfm-48-the-future-of-online-conferences-yonet77.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1067633044%3Fsecret_token%3Ds-Np3MShbrRlV&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"
+youtube_id: "KnLCHF34_VI"
 length: "18160309"
 description: "今回は、TAOドライブの米井さんをお招きして、オンライン上でのカンファレンスやミートアップ、Salesforceフロー、ふたたび受託開発の未来などについて話しました。"
 podcastLength: "00:55:30"

--- a/_posts/2022-09-12-049.md
+++ b/_posts/2022-09-12-049.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1401706390700232711/3I82fwFm_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/1342934875-migrationfm-49-long-time-no-see-im-back-ryosuke921186.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1342934875%3Fsecret_token%3Ds-CBLeYcBmxmU&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"
+youtube_id: "XTTDJSmD8lk"
 length: "22808967"
 description: "今回は、フレクトの小林さんをお招きして、近況、SFUG CUP、Dreamforce、Japan Dreamin' 2023、ワークフロールール廃止、コミュニティ活動などについて話しました。"
 podcastLength: "01:04:18"

--- a/_posts/2022-12-29-050.md
+++ b/_posts/2022-12-29-050.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/904862282068312065/EipaTmja_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/1412089192-migrationfm-50-looking-back-on-2022-yonet77.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1412089192%3Fsecret_token%3Ds-yT0nNoqmaBf&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"
+youtube_id: "4dca2WFaPug"
 length: "25600034"
 description: "今回は、TAOドライブの米井さんをお招きして、Salesforceの1年間のアップデートのふりかえりやHerokuについて話しました。"
 podcastLength: "01:20:43"

--- a/_posts/2023-05-10-051.md
+++ b/_posts/2023-05-10-051.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/770056244971331584/cILrjoMJ_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/1511106235-migrationfm-51-tech-talk-about-trailblazerdx-2023.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1511106235%3Fsecret_token%3Ds-kQ9pas3kt0o&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"
+youtube_id: "jnsfTuqADS8"
 length: "18594907"
 description: "今回は、チームスピリット社の畑本さんをお招きして、TrailblazerDX 2023で発表された Einstein GPT と Well-Architected について話しました。"
 podcastLength: "00:54:52"

--- a/_posts/2024-03-06-052.md
+++ b/_posts/2024-03-06-052.md
@@ -8,8 +8,7 @@ speaker_list:
    image_url: https://pbs.twimg.com/profile_images/1698828412264292352/zPfmNkQq_400x400.jpg
  - name: Akira Kuratani
    image_url: https://pbs.twimg.com/profile_images/754365362808827904/Ig84TgbE_400x400.jpg
-link: http://media.blubrry.com/migrationfm/http://feeds.soundcloud.com/stream/1767041055-migrationfm-52-road-to-salesforce-cta-mvp-hiroki_iida.mp3
-soundcloud_url: "https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1767041055&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"
+youtube_id: "_NatJz_Ln-s"
 length: "28272775"
 description: "今回は、先日Salesforce MVPに選出された株式会社JSOLの飯田さんをお招きして、Salesforce MVP、Salesforce Architect Group Japanでの活動や思い、Well-Architectedについて話しました。"
 podcastLength: "01:15:51"

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -202,6 +202,46 @@
   .mdl-card__supporting-text + .mdl-card__actions {
     border-top: 1px solid rgba(0, 0, 0, 0.12);
   }
+  // Apple Podcast tile
+  .apple-podcast-tile {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    color: inherit;
+    background: white;
+    margin-bottom: 16px;
+    overflow: hidden;
+
+    &__image {
+      position: relative;
+      width: 120px;
+      flex-shrink: 0;
+      background-color: #e0f7fa;
+
+      img {
+        width: 100%;
+        height: auto;
+        display: block;
+        filter: brightness(80%);
+      }
+
+      .material-icons {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        font-size: 3rem;
+        color: white;
+      }
+    }
+
+    &__label {
+      padding: 0 24px;
+      font-size: 18px;
+      font-weight: bold;
+    }
+  }
+
   // Post / Page
   .post, .page {
     section.section--center {


### PR DESCRIPTION
## Summary

- SoundCloudのサービス利用停止にともない、全エピソードのプレイヤーをYouTube/Apple Podcastsに切り替え
- ep44〜52: YouTubeプレイリストの動画をレスポンシブiframeで埋め込み
- ep000〜43: エピソード個別のApple PodcastsURLへのタイル形式リンクを表示

## 変更内容

- `_includes/soundcloud.html` → `_includes/player.html` にリネーム・作り直し
- 全53件のフロントマターを整理
  - `soundcloud_url` 削除
  - YouTubeあり: `youtube_id` 追加、`link` 削除
  - YouTubeなし: `link` → `apple_podcast_url` にリネーム（エピソード個別URL）
- Apple Podcastsリンクを一覧タイルと同デザインのカードで表示
- YouTubeiframeを `aspect-ratio: 16/9` でレスポンシブ化

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)