### PR TITLE
Fix broken RSS/podcast feed URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,9 +37,9 @@ twitter_hashtag: migrationfm
 github_username: kuratani
 youtube_channelname: migrationtalks
 facebook_pagename: migration.fm
-rss_url: https://migration.fm/feed.xml
-itunes_url: https://itunes.apple.com/jp/podcast/migration.fm/id1111956465
-andriod_url: https://www.subscribeonandroid.com/migration.fm/feed.xml
+rss_url: https://anchor.fm/s/f7b907c4/podcast/rss
+itunes_url: https://podcasts.apple.com/jp/podcast/migration-fm/id1111956465
+andriod_url: https://www.subscribeonandroid.com/anchor.fm/s/f7b907c4/podcast/rss
 blog_url: https://note.com/a_kuratani/m/m155bfd2bf627
 
 # theme: minima


### PR DESCRIPTION
## Summary

- `rss_url` を `migration.fm/feed.xml`（404）から Anchor.fm の有効なフィード URL に更新
- `itunes_url` を旧 `itunes.apple.com` から現行の `podcasts.apple.com` に更新
- `andriod_url` を新しい RSS フィード URL に更新

## Test plan

- [x] サイトのフッターにある RSS リンクが `anchor.fm/s/f7b907c4/podcast/rss` に遷移することを確認
- [x] iTunes リンクが Apple Podcasts の migration.fm ページに遷移することを確認
- [x] Android リンクが subscribeonandroid.com 経由で新しいフィードを参照していることを確認

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)